### PR TITLE
Add speed description to the select speed drop-down list

### DIFF
--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -16,13 +16,13 @@
       <form class="playback">
         <h4>Facebook Video Playback Speed</h4>
         <select name="speed">
-          <option value="0.25">Slowest</option>
-          <option value="0.5">Slower</option>
-          <option value="0.75">Slow</option>
-          <option value="1.0">Normal</option>
-          <option value="1.25">Fast</option>
-          <option value="1.5">Faster</option>
-          <option value="2.0">Fastest</option>
+          <option value="0.25">Slowest (0.25x)</option>
+          <option value="0.5">Slower (0.5x)</option>
+          <option value="0.75">Slow (0.75x)</option>
+          <option value="1.0">Normal (1.0x)</option>
+          <option value="1.25">Fast (1.25x)</option>
+          <option value="1.5">Faster (1.5x)</option>
+          <option value="2.0">Fastest (2.0x)</option>
         </select>
       </form>
       <h5>


### PR DESCRIPTION
Hi! Thank you for making this extension, it saved me a few hours as I was watching some show on fb. I was recommending it to a friend for when he watches his lectures. He asked what is the rate of which the extension increases/decreases the rate of playback. I didn't have an answer and I looked at the code just for me to tell him. I would imagine that would be impossible to do by someone with no knowledge in code.

There were also people in the reviews section in the extension page that were asking for the label.


Thank you so much. This is my first pull request, and sorry for my English.